### PR TITLE
NEURON 8.2+ compatibility

### DIFF
--- a/rand.mod
+++ b/rand.mod
@@ -56,7 +56,7 @@ VERBATIM
 /* some machines do not have drand48 and srand48 so use the implementation
 at the end of this file */
 extern double my_drand48();
-extern void my_srand48();
+extern void my_srand48(long);
 #undef drand48
 #undef srand48
 #define drand48 my_drand48
@@ -97,7 +97,7 @@ FUNCTION fran(l, h) { : returns random number between low and high
 VERBATIM
 {
 	int low, high;
-    double num, imax, *getarg();
+	double num, imax;
     
 	low = (int)_ll;
 	high = (int)_lh;
@@ -121,8 +121,6 @@ VERBATIM
     static int iset = 0;
     static float gset;
     float fac, r , v1, v2;
-    double sqrt();
-
     if (iset == 0) {
         do {
 	    	v1 = 2.0 * n_rand() - 1.0;
@@ -223,10 +221,7 @@ next()
 	x[0] = LOW(p[0]);
 }
 
-void
-my_srand48(seedval)
-long seedval;
-{
+void my_srand48(long seedval) {
 	SEED(X0, LOW(seedval), HIGH(seedval));
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,3 +14,5 @@ Note: to run, you must first unzip Iintra.dat.zip
 
 Edits:
 20220519 - zipped Iintra.dat to allow storing on GitHub
+20220523 - updated MOD files to contain valid C++ and be compatible
+           with the upcoming versions 8.2 and 9.0 of NEURON.

--- a/ri.mod
+++ b/ri.mod
@@ -24,6 +24,9 @@ NEURON { SUFFIX nothing }
 
 VERBATIM
 const char* secname();
+#ifndef _NrnThread
+#define _NrnThread NrnThread
+#endif
 ENDVERBATIM
 
 PROCEDURE scale_connection_coef(x, factor) {

--- a/ri.mod
+++ b/ri.mod
@@ -24,9 +24,6 @@ NEURON { SUFFIX nothing }
 
 VERBATIM
 const char* secname();
-#ifndef _NrnThread
-#define _NrnThread NrnThread
-#endif
 ENDVERBATIM
 
 PROCEDURE scale_connection_coef(x, factor) {
@@ -34,7 +31,7 @@ VERBATIM {
 	Section* sec;
 	Node* nd;
 #if defined(t)
-	_NrnThread* _nt = nrn_threads;
+	NrnThread* _nt = nrn_threads;
 #endif
 	sec = chk_access();
 	if (_lx <= 0. || _lx > 1.) {


### PR DESCRIPTION
Compared to the other changes focused on the C++ migration, the `_NrnThread` issue is older.